### PR TITLE
Add C++20 flag to MSVC params

### DIFF
--- a/src/nue.nim
+++ b/src/nue.nim
@@ -108,7 +108,8 @@ let platformSwitches: Switches =
   block:
     when defined windows:
       @[
-        ("cc", "vcc")
+        ("cc", "vcc"),
+        passC("/std:c++20")
       ]
     elif defined macosx:
       let platformDir = 


### PR DESCRIPTION
This fixes the compiler throwing a bunch of errors related to folding during `nue guest`.