### PR TITLE
Change type overflow check from try except to an if check

### DIFF
--- a/src/nimforue/unreal/coreuobject/uobjectflags.nim
+++ b/src/nimforue/unreal/coreuobject/uobjectflags.nim
@@ -373,10 +373,12 @@ macro genEnumOperators(eSym, typSym:typed, genValConverters : static bool = true
     let converters = genAst(name, valName=ident enumName&"Val", typ):
         converter toValName*(a:name) : valName = valName(typ(ord(a)))
         converter toName*(a:valName) : name = 
-            try:
-                name(typ(a))
-            except:
-                name(0) #prevents a type overflow when parsing engine types. 
+            let val = typ(a)
+            #prevents a type overflow when parsing engine types. 
+            if val <= (uint64)high(name):
+                name(val)
+            else:
+                name(0)
     
     if genValConverters:
         result.add converters


### PR DESCRIPTION
Was regenerating my bindings for Unreal 5.1 and I was getting this error:
```
E:\Projects\DrinkGame\Plugins\NimForUE\src\nimforue\unreal\coreuobject\uobjectflags.nim(377, 21) Error: illegal conversion from '42784299539243013' to '[0..36028797018963968]'
fatal.nim(53)            sysFatal
Error: unhandled exception: nue.nim(147, 11) `execCmd(&"nim cpp --mm:orc --compileonly -f --nomain --maxLoopIterationsVM:400000000 --nimcache:.nimcache/projectbindings src/codegen/genprojectbindings.nim") ==
    0`  [AssertionDefect]
```
I think the macro system doesn't allow `try except` like that at compile time. This PR just changes it to a if check.