### PR TITLE
Add ssl to game lib

### DIFF
--- a/src/buildscripts/nuecompilation/nuecompilation.nim
+++ b/src/buildscripts/nuecompilation/nuecompilation.nim
@@ -141,7 +141,7 @@ proc compileLib*(name:string, extraSwitches:seq[string], withDebug:bool) =
     "-d:libname:" & name,
     (if isVm: "-d:vmhost" else: ""),
     &"-d:BindingPrefix={PluginDir}/.nimcache/gencppbindings/@m..@sunreal@sbindings@sexported@s",
-
+    "-d:ssl",
   ] 
   let isCompileOnly = "--compileOnly" in extraSwitches
   if isCompileOnly:


### PR DESCRIPTION
This allows me to use ssl httpclient without crashing the game. Maybe it's a bad idea to include ssl, and this should be behind a config option? It feels like a reasonable default to me though.
Let me know if this flag should go elsewhere.