### PR TITLE
Fixed various things to make building from source easier.

### DIFF
--- a/Source/NimForUE/NimForUE.Build.cs
+++ b/Source/NimForUE/NimForUE.Build.cs
@@ -139,7 +139,7 @@ public class NimForUE : ModuleRules
 			dynLibPath = Path.Combine(nimBinPath, "libhostnimforue.dylib");
 			PublicAdditionalLibraries.Add(dynLibPath);
 		}
-		
+
         setUEConfig(EngineDirectory, Target.Configuration.ToString(), Target.Platform.ToString(), Target.bBuildEditor);
 
 		//PublicDefinitions.Add($"NIM_FOR_UE_LIB_PATH  \"{dynLibPath}\"");

--- a/Source/NimForUE/NimForUE.Build.cs
+++ b/Source/NimForUE/NimForUE.Build.cs
@@ -13,8 +13,8 @@ public class NimForUE : ModuleRules
 	[DllImport("hostnimforue")]
 	public static extern void setWinCompilerSettings(string sdkVersion, string compilerVersion, string toolchainDir);
 
-	[DllImport("libhostnimforue")]
-	public static extern void setUEConfig(string engineDir,string conf,string platform, bool withEditor);
+	[DllImport("hostnimforue")]
+	public static extern void setUEConfig(string engineDir, string conf, string platform, bool withEditor);
 
 	[DllImport("hostnimforue")]
 	static extern IntPtr getNimBaseHeaderPath();
@@ -86,7 +86,7 @@ public class NimForUE : ModuleRules
 			PublicDefinitions.Add("NUE_GAME=1");
 			Console.WriteLine("Found an user custom header nuegame.h Adding it to the PCH");
 		}
-			
+
 
 		if (Target.bBuildEditor) {
 			AddNimForUEDev();
@@ -107,9 +107,6 @@ public class NimForUE : ModuleRules
 		try {
 			var process = Process.Start(processInfo);
 			process.WaitForExit();
-			var nimBinPath = Path.Combine(PluginDirectory, "Binaries", "nim", "ue", "libhostnimforue.dylib");
-			Console.WriteLine((Target.ProjectFile.Directory.ToString()));
-			//setUEConfig(EngineDirectory, Target.Configuration.ToString(), Target.Platform.ToString(), Target.bBuildEditor);
 		}
 		
 
@@ -143,12 +140,12 @@ public class NimForUE : ModuleRules
 			PublicAdditionalLibraries.Add(dynLibPath);
 		}
 		
-		
+        setUEConfig(EngineDirectory, Target.Configuration.ToString(), Target.Platform.ToString(), Target.bBuildEditor);
+
 		//PublicDefinitions.Add($"NIM_FOR_UE_LIB_PATH  \"{dynLibPath}\"");
 		//TRY?
 		try {
 			//BuildNim();
-			//setNimForUEConfig(PluginDirectory, EngineDirectory, Target.Platform.ToString(), Target.Configuration.ToString());
 			if (Target.Platform == UnrealTargetPlatform.Win64)
 				setWinCompilerSettings(Target.WindowsPlatform.WindowsSdkVersion, Target.WindowsPlatform.CompilerVersion, Target.WindowsPlatform.ToolChainDir);
 			Console.WriteLine(Target.WindowsPlatform.ToolChainDir);	

--- a/Source/NimForUE/NimForUE.Build.cs
+++ b/Source/NimForUE/NimForUE.Build.cs
@@ -98,23 +98,31 @@ public class NimForUE : ModuleRules
 		bUseUnity = false;
 	}
 
-	void NimbleSetup() {
+	void runNimble(String command)
+	{
 		var processInfo = new ProcessStartInfo();
 		processInfo.WorkingDirectory = PluginDirectory;
-		Console.WriteLine("Running nimble setup in", PluginDirectory);
+		Console.WriteLine("== NimForUE.Build.cs - Running nimble " + command + "==", PluginDirectory);
 		processInfo.FileName = "nimble" + (Target.Platform == UnrealTargetPlatform.Win64 ? ".exe" : ""); 
-		processInfo.Arguments = "ok";
+		processInfo.Arguments = command;
+		Console.WriteLine(processInfo.FileName);
 		try {
 			var process = Process.Start(processInfo);
 			process.WaitForExit();
-		}
-		
-
-		catch (Exception e) {
-			Console.WriteLine("There was a problem trying to run nimble.");
+		} catch (Exception e) {
+			Console.WriteLine("There was a problem trying to run nimble " + command);
 			Console.WriteLine(e.Message);
 			Console.WriteLine(e.StackTrace);
 		}
+	}
+
+	void NimbleSetup() {
+		if (!File.Exists(Path.Combine(PluginDirectory, "nue" + (Target.Platform == UnrealTargetPlatform.Win64 ? ".exe" : "")))) {
+			Console.WriteLine("nue needs to be built");
+			runNimble("nue");
+		}
+
+		runNimble("ok");
 	}
 
 	//TODO Run buildlibs from here so the correct config/platform is picked when building

--- a/Source/NimForUE/Private/GenerateBindingsCommandlet.cpp
+++ b/Source/NimForUE/Private/GenerateBindingsCommandlet.cpp
@@ -8,6 +8,8 @@
 #include "ReflectionHelpers.h"
 #include "NimForUEEditor/NimForUEEditor.h"
 
+#include "Misc/EngineVersionComparison.h"
+
 UGenerateBindingsCommandlet::UGenerateBindingsCommandlet() {
 
 }
@@ -22,7 +24,9 @@ int32 UGenerateBindingsCommandlet::Main(const FString& Params) {
 	FGenericPlatformProcess::ConditionalSleep([]{return true;}, 2000);
 
 	// registerLogger(logger);
+#if UE_VERSION_OLDER_THAN(5, 5, 0)
 	CommandletHelpers::TickEngine();
+#endif
 	// ensureGuestIsCompiled();
 	checkReload(3); 
     genBindingsEntryPoint();

--- a/Source/NimForUEBindings/Public/NimScriptStruct.h
+++ b/Source/NimForUEBindings/Public/NimScriptStruct.h
@@ -20,6 +20,7 @@
 		virtual FCapabilities GetCapabilities() const override
 		{
 #if  (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+			// pulled from Runtime\CoreUObject\Public\UObject\Class.h
 			constexpr FCapabilities Capabilities {
 				(TIsPODType<CPPSTRUCT>::Value ? CPF_IsPlainOldData : CPF_None)
 				| (std::is_trivially_destructible_v<CPPSTRUCT> ? CPF_NoDestructor : CPF_None)
@@ -409,7 +410,7 @@
 
 #if  (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
 
-//5.5 up
+//5.5 up, pulled from Runtime\CoreUObject\Private\UObject\Class.h
 		/** Construct an unset optional value */
 		virtual void InitializeIntrusiveUnsetOptionalValue(void* Data) const
 		{
@@ -446,6 +447,18 @@
 			else
 			{
 				return EPropertyVisitorControlFlow::StepOver;
+			}
+		}
+
+		virtual void* ResolveVisitedPathInfo(void* Data, const FPropertyVisitorInfo& Info) const
+		{
+			if constexpr (TStructOpsTypeTraits<CPPSTRUCT>::WithVisitor)
+			{
+				return ((CPPSTRUCT*)Data)->ResolveVisitedPathInfo(Info);
+			}
+			else
+			{
+				return nullptr;
 			}
 		}
 #endif

--- a/src/hostnimforue/hostwatcher.nim
+++ b/src/hostnimforue/hostwatcher.nim
@@ -45,7 +45,7 @@ proc setUEConfig(engineDir, conf, platform : cstring, withEditor:bool)=
     let (_,gameDir) = tryGetEngineAndGameDir().get()
     let conf = 
         NimForUEConfig(engineDir: $engineDir, gameDir: $gameDir, 
-            targetConfiguration: targetConf, targetPlatform: targetPlatform)
+            targetConfiguration: targetConf, targetPlatform: targetPlatform, withEditor: withEditor)
     conf.saveConfig()
 
 var currentLoadPhase = nlfPreEngine #First time check reload is called is preengine


### PR DESCRIPTION
With these changes the user can:
Download the Unreal source (e.g. ue5-main)
Build Unreal using the typical workflow (Setup, generate the solution, etc)
Create a new project
Clone NimForUE into the Plugins folder
Generate the solution for Visual Studio
Build the project (this build the nue executable if needed)
Then from the terminal run `nue setup` to generate the bindings and build game.nim.

Tested with ue5-main version 5.5.