### PR TITLE
docs: 📚 add troubleshoot section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -190,3 +190,12 @@ Which produces:
 A video showcasing the installation process in more detail:
 
 [![Installing NimForUE video](https://img.youtube.com/vi/sT8-Oz7k-VU/0.jpg)](https://youtu.be/sT8-Oz7k-VU)
+
+
+## Troubleshooting
+
+### Windows
+- The project path must not be too long, the default location `C:/Users/<USER>/Unreal Projects` is too long for instance.
+- The project path must not contain spaces, the default location `C:/Users/<USER>/Unreal Projects` will break as it contain spaces.
+
+For both issues you can move the "Unreal Projects" folder to the root of a drive and symlink it back to the user document directory if needed by other process / applications.


### PR DESCRIPTION
These suggestions come from my experience explained in #43 
The wording might not be the best but I think having the info somewhere is important, feel free to edit it.

The **TLDR** is:

- If there is a space in the project dir path, it will break nue who will start to look for projects files in the Engine directory.
- If the project dir path is too long (even with long paths enabled) it will break the link step (see the last message of #43) or here on discord: https://discord.com/channels/1043555753904050237/1043555756798128200/1241403772807417979

Thanks