### PR TITLE
Some small improvements

### DIFF
--- a/src/nimforue/codegen/uebind.nim
+++ b/src/nimforue/codegen/uebind.nim
@@ -191,7 +191,9 @@ func genFunc*(typeDef : UEType, funField : UEField, typeExposure: UEExposure = u
               formalParams, 
               pragmas, newEmptyNode(),
             ])
-  var impl = forwardDeclaration
+
+  var impl = forwardDeclaration.copyNimTree()
+  forwardDeclaration.add newEmptyNode()
   impl.add(fnBody)
   (forwardDeclaration,impl)
 

--- a/src/nimforue/codegen/uebindcore.nim
+++ b/src/nimforue/codegen/uebindcore.nim
@@ -325,7 +325,7 @@ func getFieldIdentWithPCH*(typeDef: UEType, prop:UEField, isImportCpp: bool = fa
     getFieldIdent(prop)
 
 #UEEMit
-func fromNinNodeToMetadata*(node : NimNode) : seq[UEMetadata] =
+func fromNimNodeToMetadata*(node : NimNode) : seq[UEMetadata] =
     case node.kind:
     of nnkIdent:
         @[makeUEMetadata(node.strVal())]
@@ -362,7 +362,7 @@ func getMetasForType*(body:NimNode) : seq[UEMetadata] {.compiletime.} =
         .mapIt(it.children.toSeq())
         .flatten()
         .filterIt(it.kind!=nnkExprColonExpr)
-        .map(fromNinNodeToMetadata)
+        .map(fromNimNodeToMetadata)
         .flatten()
 
 #some metas (so far only uprops)
@@ -430,7 +430,7 @@ func fromUPropNodeToField(node : NimNode, ueTypeName:string) : seq[UEField] =
     let validNodesForMetas = [nnkIdent, nnkExprEqExpr]
     let metasAsNodes = node.childrenAsSeq()
                     .filterIt(it.kind in validNodesForMetas or (it.kind == nnkIdent and it.strVal().toLower() notin ValidUprops))
-    let ueMetas = metasAsNodes.map(fromNinNodeToMetadata).flatten().tail()
+    let ueMetas = metasAsNodes.map(fromNimNodeToMetadata).flatten().tail()
     let metas = metasAsNodes
                     .filterIt(it.kind == nnkIdent)
                     .mapIt(it.strVal())

--- a/src/nimforue/codegen/umacros.nim
+++ b/src/nimforue/codegen/umacros.nim
@@ -1,4 +1,4 @@
-import std/[sequtils, macros, genasts, sugar, json, jsonutils, strutils, tables, options, strformat, hashes, algorithm]
+import std/[sequtils, macros, genasts, sugar, json, jsonutils, strutils, tables, options, strformat, hashes, algorithm, macros]
 import uebindcore, models, modelconstructor, enumops
 import ../utils/[ueutils,utils]
 
@@ -70,10 +70,10 @@ proc getTypeNodeFromUClassName(name:NimNode) : (string, string, seq[string]) =
     let className = name[1].strVal()
     case name[^1].kind:
     of nnkIdent: 
-        let parent = name[^1].strVal()        
+        let parent = name[^1].strVal()
         (className, parent, newSeq[string]())
     of nnkCommand:
-        let parent = name[^1][0].strVal()        
+        let parent = name[^1][0].strVal()
         var ifaces = 
             name[^1][^1][^1].strVal().split(",") 
         if ifaces[0][0] == 'I':
@@ -90,7 +90,7 @@ func funcBlockToFunctionInUClass(funcBlock : NimNode, ueTypeName:string) :  tupl
     let metas = funcBlock.childrenAsSeq()
                     .tail() #skip ufunc and variations
                     .filterIt(it.kind==nnkIdent or it.kind==nnkExprEqExpr)
-                    .map(fromNinNodeToMetadata)
+                    .map(fromNimNodeToMetadata)
                     .flatten()
     let firstParam = some makeFieldAsUPropParam("self", ueTypeName.addPtrToUObjectIfNotPresentAlready(), ueTypeName, CPF_None) #notice no generic/var allowed. Only UObjects
     let allFuncs = funcBlock[^1].children.toSeq()
@@ -312,7 +312,6 @@ macro uClass*(name:untyped, body : untyped) : untyped =
   let (uClassNode, fns, _) = uClassImpl(name, body, true)
   result = nnkStmtList.newTree(@[uClassNode] & fns)
 
- 
 
 func getRawClassTemplate(isSlate: bool, interfaces: seq[string]): string = 
   var cppInterfaces = interfaces.filterIt(it[0] == 'I').mapIt("public " & it).join(", ")

--- a/src/nimforue/utils/utils.nim
+++ b/src/nimforue/utils/utils.nim
@@ -291,3 +291,13 @@ proc tryGetJson*[T](json:JsonNode, key:string) : Option[T] =
 proc objectLen*(T: typedesc[object]) : int =  
   for field in default(T).fields:    
     inc result
+
+
+
+# calls debugEcho with the lineInfo
+macro here*(x: varargs[typed, `$`]):untyped {.noSideEffect.} =
+  {.cast(noSideEffect).}:
+    result = newTree(nnkCommand, ident "debugEcho")
+    result.add newStrLitNode("=== " & x[0].lineInfo & " : "& x.toStrLit().strVal & " ===\n")
+    for c in x:
+      result.add c


### PR DESCRIPTION
We can use `here` instead of `debugEcho`. Makes it easier to hunt down debug logging, so we can comment or remove it to keep the output cleaner.

The fix for forwardDeclaration doesn't seem to change the behavior of anything, but if intention is to create a forwardDecl we need to copyNimTree and give it an empty body.