### PR TITLE
fixed adding gameModules to NimForUEBindings.Build.cs dependencies

### DIFF
--- a/Source/NimForUEBindings/NimForUEBindings.Build.cs
+++ b/Source/NimForUEBindings/NimForUEBindings.Build.cs
@@ -58,8 +58,11 @@ public class NimForUEBindings : ModuleRules
 				"AdvancedPreviewScene"
 			});
 			AddHostDll();
-			var gameModules = Marshal.PtrToStringAnsi(getGameModules()).Split(",");
-			PublicDependencyModuleNames.AddRange(gameModules);
+			var gameModulesStr = Marshal.PtrToStringAnsi(getGameModules());
+			if (!String.IsNullOrEmpty(gameModulesStr))
+			{
+				PublicDependencyModuleNames.AddRange(gameModulesStr.Split(","));
+			}
 		}
 		if (Target.Platform == UnrealTargetPlatform.Win64){
 			CppStandard = CppStandardVersion.Cpp20;


### PR DESCRIPTION
The project couldn't be built  if the getGameModules call returns empty. Added a check in there so an empty module isn't added to the `PublicDependencyModuleNames`.