### PR TITLE
Fix for 'super_' exportcpp collision

### DIFF
--- a/src/nimforue/codegen/uebind.nim
+++ b/src/nimforue/codegen/uebind.nim
@@ -173,6 +173,11 @@ func genFunc*(typeDef : UEType, funField : UEField, typeExposure: UEExposure = u
 
   var pragmas = 
     # when WithEditor:
+    if isSuper:
+      nnkPragma.newTree(
+        nnkExprColonExpr.newTree(ident "exportcpp", newStrLitNode(clsName&"_"&funField.actualFunctionName&"_$1_"))
+        ) #export the func with clsName and function to avoid super_ collision
+    else:
       nnkPragma.newTree(
         nnkExprColonExpr.newTree(ident "exportcpp", newStrLitNode("$1_"))
         ) #export the func with an underscore to avoid collisions

--- a/src/nimforue/codegen/umacros.nim
+++ b/src/nimforue/codegen/umacros.nim
@@ -315,6 +315,9 @@ macro uClass*(name:untyped, body : untyped) : untyped =
   let (uClassNode, fns, _) = uClassImpl(name, body, true)
   result = nnkStmtList.newTree(@[uClassNode] & fns)
 
+  #if name[1].eqIdent("AAuraPlayerController"):
+  #  here result.repr
+
 
 func getRawClassTemplate(isSlate: bool, interfaces: seq[string]): string = 
   var cppInterfaces = interfaces.filterIt(it[0] == 'I').mapIt("public " & it).join(", ")


### PR DESCRIPTION
When multiple ufuncs use `self.super`, you get a error about `super_` collision. For example:

```
D:\unreal-projects\_experiments\NueAuraGas\Plugins\NimForUE\src\nimforue\codegen\uebind.nim(196): error C2084: function 'void super_(AAuraPlayerController *)' already has a body
D:\unreal-projects\_experiments\NueAuraGas\Plugins\NimForUE\src\nimforue\codegen\uebind.nim(196): note: see previous definition of 'super_'
D:\unreal-projects\_experiments\NueAuraGas\NimForUE\player\auraplayercontroller.nim(31): error C2065: 'super_': undeclared identifier
``` 

This patch does a check in uebind `genFunc` for `isSuper` when creating the exportcpp pragma and prefixes the class and method name to the export.