### PR TITLE
The latest version of Nim makes `setMetaData` in `nimforuebindings.nim` ambiguous between the UFi…

### DIFF
--- a/src/nimforue/codegen/uemeta.nim
+++ b/src/nimforue/codegen/uemeta.nim
@@ -1009,14 +1009,14 @@ proc emitUEnum*(enumType: UEType, package: UPackagePtr): UFieldPtr =
   const objFlags = RF_Public | RF_Transient | RF_MarkAsNative
   let uenum = newUObject[UNimEnum](package, name, objFlags)
   for metadata in enumType.metadata:
-    uenum.setMetadata(makeFName metadata.name, $metadata.value)
+    uenum.setMetadata(f metadata.name, $metadata.value)
   var enumFields = makeTArray[TPair[FName, int64]]()
   for field in enumType.fields.pairs:
     let fieldName = field.val.name.makeFName()
     enumFields.add(makeTPair(fieldName, field.key.int64))
     # uenum.setMetadata("DisplayName", "Whatever"&field.val.name)) TODO the display name seems to be stored into a metadata prop that isnt the one we usually use
   discard uenum.setEnums(enumFields)
-  uenum.setMetadata(makeFName UETypeMetadataKey, $enumType.toJson())
+  uenum.setMetadata(f UETypeMetadataKey, $enumType.toJson())
 
   uenum
 

--- a/src/nimforue/unreal/nimforue/nimforuebindings.nim
+++ b/src/nimforue/unreal/nimforue/nimforuebindings.nim
@@ -76,7 +76,7 @@ when WithEditor:
 # when true:
     proc setMetadata*(field: FFieldPtr, key: FName, inValue:FString) : void {.importcpp:"#->SetMetaData(#, *#)".}
     proc setMetadata*(field: UFieldPtr, key: FName, inValue:FString): void {.importcpp:"#->SetMetaData(#, *#)".}
-    proc setMetadata*(field: UEnumPtr, key: FName, inValue:FString): void {.importcpp:"#->SetMetaData(*(#.ToString()), *#)".}
+    proc setMetadata*(field: UEnumPtr, key: FString, inValue:FString): void {.importcpp:"#->SetMetaData(*#, *#)".}
     
     # proc setMetadata*(field: UFieldPtr, key:FString, inValue:FString): void {.importcpp:"#->SetMetaData(#, *#)".}
     # proc setMetadata*(field:UFieldPtr|FFieldPtr, key:FName, inValue:FString) : void = setMetadataInternal(field, key.toFString(), inValue)


### PR DESCRIPTION
…eld and UEnum versions, since UEnum derives from UField. On the C++ side of things UEnum only defines a `SetMetaData` on `TCHAR*` so I mapped that to FString.
Class.h
```c++
	COREUOBJECT_API void SetMetaData( const TCHAR* Key, const TCHAR* InValue, int32 NameIndex=INDEX_NONE) const;
```